### PR TITLE
Add docs and metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+Run `cargo test` before committing any changes.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Hermes
+
+Hermes is a small experimental HTTP library used for exercises on Codex.
+
+## Building
+
+```bash
+cargo build
+```
+
+## Running tests
+
+```bash
+cargo test
+```
+
+The library contains utilities for parsing and generating HTTP messages. All
+core types are available under the `http` module.

--- a/src/concepts.rs
+++ b/src/concepts.rs
@@ -1,3 +1,4 @@
+//! Common data structures and helpers used across the crate.
 use std::collections::HashMap;
 
 /// A type alias for a `HashMap` where the keys are `String`
@@ -135,6 +136,7 @@ pub fn identifier(input: &str) -> IResult<&str, &str> {
 }
 
 #[derive(Debug, Clone)]
+/// Represents a generic JSON-like value used when parsing parameters.
 pub enum Value {
     Null,
     Bool(bool),

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,3 +1,4 @@
+//! High level HTTP types and re-exports.
 mod message;
 pub use message::*;
 

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -1,3 +1,4 @@
+//! Structures and helpers for HTTP responses.
 use crate::concepts::Parsable;
 use crate::http::message::Headers;
 use crate::http::{Message, MessageTrait, Version};
@@ -8,6 +9,7 @@ use nom::IResult;
 use std::fmt::{Display, Formatter};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+/// HTTP status codes and reasons recognized by the library.
 pub enum Status {
     /// 100
     Continue,
@@ -145,6 +147,7 @@ pub enum Status {
 }
 
 impl Status {
+    /// Return the numeric HTTP status code.
     pub fn to_code(&self) -> u16 {
         match self {
             Self::Continue => 100,
@@ -213,6 +216,7 @@ impl Status {
         }
     }
 
+    /// Convert a numeric code to a [`Status`] variant.
     pub fn from_code(code: u16) -> Self {
         match code {
             100 => Self::Continue,
@@ -294,6 +298,7 @@ impl Status {
         }
     }
 
+    /// Convert a reason phrase to a [`Status`] variant.
     pub fn from_reason(reason: &str) -> Self {
         match reason {
             "Continue" => Self::Continue,
@@ -367,6 +372,7 @@ impl Status {
         }
     }
 
+    /// Return the canonical reason phrase for this status.
     pub fn to_reason(&self) -> &str {
         match self {
             Self::Continue => "Continue",
@@ -435,22 +441,27 @@ impl Status {
         }
     }
 
+    /// Check if the status code is within the informational range (1xx).
     pub fn is_informational(&self) -> bool {
         (100..=199).contains(&self.to_code())
     }
 
+    /// Check if the status represents success (2xx).
     pub fn is_successful(&self) -> bool {
         (200..=299).contains(&self.to_code())
     }
 
+    /// Check if the status is a redirection code (3xx).
     pub fn is_redirection(&self) -> bool {
         (300..=399).contains(&self.to_code())
     }
 
+    /// Check if the status is a client error (4xx).
     pub fn is_client_error(&self) -> bool {
         (400..=499).contains(&self.to_code())
     }
 
+    /// Check if the status is a server error (5xx).
     pub fn is_server_error(&self) -> bool {
         (500..=599).contains(&self.to_code())
     }
@@ -495,6 +506,7 @@ impl Parsable for Status {
 
 
 
+/// Behaviour shared by HTTP response types.
 pub trait ResponseTrait: MessageTrait {
     fn status(&self) -> Status;
     fn code(&self) -> u16 {

--- a/src/http/uri.rs
+++ b/src/http/uri.rs
@@ -1,3 +1,4 @@
+//! Types for parsing and representing URIs.
 use crate::concepts::{both_or_none, Parsable};
 use crate::http::request::Query;
 use nom::bytes::complete::{tag, take_till, take_until};
@@ -10,6 +11,7 @@ use nom::IResult;
 use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Default, Clone)]
+/// Represents the resource path and optional extra path info of a URI.
 pub struct Path {
     pub resource: String,
     pub path_info: Option<String>,
@@ -27,6 +29,7 @@ impl Display for Path {
 }
 
 impl Path {
+    /// Create a new [`Path`] with the provided resource and optional path info.
     pub fn new(resource: String, path_info: Option<String>) -> Self {
         Self {
             resource,
@@ -82,6 +85,7 @@ impl Parsable for Path {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+/// User information, host and port part of a URI.
 pub struct Authority {
     pub host: String,
     pub user: Option<String>,
@@ -90,6 +94,7 @@ pub struct Authority {
 }
 
 impl Authority {
+    /// Create a new [`Authority`] instance from its components.
     pub fn new(
         host: String,
         user: Option<String>,
@@ -106,6 +111,7 @@ impl Authority {
 }
 
 impl Authority {
+    /// Parse `user:password` information from an authority string.
     pub fn parse_user_info(input: &str) -> IResult<&str, (Option<String>, Option<String>)> {
         let user: Option<String>;
         let mut password: Option<String> = None;
@@ -120,6 +126,7 @@ impl Authority {
         Ok(("", (user, password)))
     }
 
+    /// Parse the host and optional port from an authority part.
     pub fn parse_host(input: &str) -> IResult<&str, (String, Option<u16>)> {
         let host: String;
         let mut port: Option<u16> = None;
@@ -135,6 +142,7 @@ impl Authority {
 }
 
 impl Parsable for Authority {
+    /// Parse the authority component of a URI.
     fn parse(input: &str) -> IResult<&str, Self>
     where
         Self: Sized,
@@ -174,6 +182,7 @@ impl Parsable for Authority {
 }
 
 #[derive(Debug, Default, Clone)]
+/// A fully parsed Uniform Resource Identifier.
 pub struct Uri {
     pub scheme: String,
     pub authority: Authority,
@@ -183,6 +192,7 @@ pub struct Uri {
 }
 
 impl Parsable for Uri {
+    /// Parse a URI from a string slice.
     fn parse(input: &str) -> IResult<&str, Self>
     where
         Self: Sized,
@@ -239,6 +249,7 @@ impl Uri {
     pub const SCHEME_SSH: &'static str = "ssh";
 
     #[allow(clippy::too_many_arguments)]
+    /// Construct a new [`Uri`] from its components.
     pub fn new(
         scheme: String,
         authority: Authority,
@@ -255,6 +266,7 @@ impl Uri {
         }
     }
 
+    /// Format the authority component back to a string.
     pub fn authority(&self) -> String {
         let user_info = format!(
             "{}{}",
@@ -281,6 +293,7 @@ impl Uri {
         )
     }
 
+    /// Return a clone of the [`Path`] component.
     pub fn path(&self) -> Path {
         self.path.clone()
     }


### PR DESCRIPTION
## Summary
- document modules and functions in HTTP code
- add MIT license
- add developer README
- add AGENTS guidelines

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684af13ccb48832f98837f10e506a72a