### PR TITLE
Refactor helper name for clarity

### DIFF
--- a/src/concepts.rs
+++ b/src/concepts.rs
@@ -56,17 +56,17 @@ pub type BoxVec<T> = Vec<Box<T>>;
 /// # Examples
 ///
 /// ```
-/// use hermes::concepts::both_or_none;
+/// use hermes::concepts::concat_if_both;
 ///
-/// let empty0 = both_or_none("prefix", "");
-/// let empty1 = both_or_none("", "suffix");
-/// let appended     = both_or_none("prefix", "suffix");
+/// let empty0 = concat_if_both("prefix", "");
+/// let empty1 = concat_if_both("", "suffix");
+/// let appended     = concat_if_both("prefix", "suffix");
 ///
 /// assert_eq!(empty0, "");
 /// assert_eq!(empty1, "");
 /// assert_eq!(appended, "prefixsuffix");
 /// ```
-pub fn both_or_none(prefix: &str, suffix: &str) -> String {
+pub fn concat_if_both(prefix: &str, suffix: &str) -> String {
     if !(prefix.is_empty() || suffix.is_empty()) {
         format!("{}{}", prefix, suffix)
     } else {
@@ -151,10 +151,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_both_or_none() {
-        assert_eq!(both_or_none("pre", "suf"), "presuf");
-        assert_eq!(both_or_none("pre", ""), "");
-        assert_eq!(both_or_none("", "suf"), "");
+    fn test_concat_if_both() {
+        assert_eq!(concat_if_both("pre", "suf"), "presuf");
+        assert_eq!(concat_if_both("pre", ""), "");
+        assert_eq!(concat_if_both("", "suf"), "");
     }
 
     #[test]

--- a/src/http/uri.rs
+++ b/src/http/uri.rs
@@ -1,5 +1,5 @@
 //! Types for parsing and representing URIs.
-use crate::concepts::{both_or_none, Parsable};
+use crate::concepts::{concat_if_both, Parsable};
 use crate::http::request::Query;
 use crate::http::ParseError;
 use nom::bytes::complete::{tag, take_till, take_until};
@@ -285,7 +285,7 @@ impl Uri {
 
         format!(
             "{}{}{}",
-            both_or_none(&user_info, "@"),
+            concat_if_both(&user_info, "@"),
             self.authority.host,
             self.authority
                 .port
@@ -306,18 +306,18 @@ impl Display for Uri {
         write!(
             f,
             "{}{}{}{}{}",
-            both_or_none(&self.scheme, ":"),
-            both_or_none(
+            concat_if_both(&self.scheme, ":"),
+            concat_if_both(
                 "//",
                 &if path.resource.is_empty() {
                     self.authority()
                 } else {
-                    both_or_none(&self.authority(), "/")
+                    concat_if_both(&self.authority(), "/")
                 }
             ),
             path,
-            both_or_none("?", &self.query.to_string()),
-            both_or_none("#", &self.fragment.clone().unwrap_or("".to_string())),
+            concat_if_both("?", &self.query.to_string()),
+            concat_if_both("#", &self.fragment.clone().unwrap_or("".to_string())),
         )
     }
 }


### PR DESCRIPTION
## Summary
- rename `both_or_none` to `concat_if_both`
- update all references and tests

## Testing
- `cargo test`
- `cargo fmt --all` *(fails: expected identifier, found keyword `crate`)*

------
https://chatgpt.com/codex/tasks/task_e_684b70c01880832fa40831ee95fae9bb