### PR TITLE
Improve documentation coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +199,7 @@ dependencies = [
  "clap",
  "nom",
  "tokio",
+ "tokio-test",
 ]
 
 [[package]]
@@ -382,6 +411,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 nom = "8.*"
 tokio = { version = "1.45.1", features = ["full"] }
 clap = { version = "4.5", features = ["derive"] }
+
+[dev-dependencies]
+tokio-test = "0.4"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,34 +1,51 @@
+use crate::concepts::Parsable;
+use crate::http::{Headers, Request, Response, Version};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
-use crate::http::{Headers, Request, Response, Version};
-use crate::concepts::Parsable;
 
 /// Minimal asynchronous HTTP client.
+///
+/// # Examples
+///
+/// ```no_run
+/// use hermes::client::Client;
+/// use hermes::http::ResponseTrait;
+/// # tokio_test::block_on(async {
+/// let response = Client::get("http://example.com").await.unwrap();
+/// println!("{}", response.code());
+/// # })
+/// ```
 pub struct Client {
     stream: TcpStream,
 }
 
 impl Client {
-    
     pub async fn new(host: String, port: u16) -> Self {
         Self {
-            stream: TcpStream::connect(format!("{}:{}", host, port)).await.unwrap()
+            stream: TcpStream::connect(format!("{}:{}", host, port))
+                .await
+                .unwrap(),
         }
     }
-    
+
     pub async fn send(&mut self, request: Request) -> std::io::Result<Response> {
-        self.stream.write_all(request.to_string().as_bytes()).await?;
+        self.stream
+            .write_all(request.to_string().as_bytes())
+            .await?;
         self.stream.shutdown().await?;
         let mut buf = Vec::new();
         self.stream.read_to_end(&mut buf).await?;
         let text = String::from_utf8_lossy(&buf);
-        let (_, response) = Response::parse(&text).map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid response"))?;
+        let (_, response) = Response::parse(&text).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "invalid response")
+        })?;
         Ok(response)
     }
-    
+
     /// Convenience helper to perform a GET request to `url`.
     pub async fn get(url: &str) -> std::io::Result<Response> {
-        let (_, uri) = crate::http::Uri::parse(url).map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid url"))?;
+        let (_, uri) = crate::http::Uri::parse(url)
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid url"))?;
         let mut headers = Headers::new();
         headers.insert("Host", &[uri.authority.host.clone()]);
         let factory = crate::http::RequestFactory::version(Version::Http1_1);

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,9 @@
 //! High level HTTP types and re-exports.
+//!
+//! This module groups everything related to parsing or generating HTTP
+//! messages.  It is structured into several submodules which are all re-
+//! exported at the module root for convenience so that most types can be
+//! accessed as `hermes::http::Request`, `hermes::http::Response` and so on.
 mod message;
 pub use message::*;
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -27,8 +27,7 @@ impl Parsable for Method {
     where
         Self: Sized,
     {
-        let (input, method) =
-            take_while1(|c: char| c.is_ascii_alphanumeric() || c == '-')(input)?;
+        let (input, method) = take_while1(|c: char| c.is_ascii_alphanumeric() || c == '-')(input)?;
         let upper = method.to_uppercase();
         Ok((
             input,
@@ -70,7 +69,6 @@ impl Display for Method {
 }
 
 impl Method {
-
     /// Returns `true` if requests with this method usually contain a body.
     pub fn request_has_body(&self) -> bool {
         match self {
@@ -127,6 +125,23 @@ impl Method {
 }
 
 #[derive(Debug, Default, Clone)]
+/// Representation of a URI query string.
+///
+/// The structure behaves like a simple map of key/value pairs and offers
+/// helpers to manipulate its contents.
+///
+/// # Examples
+/// ```
+/// use hermes::http::Query;
+/// use hermes::concepts::Parsable;
+///
+/// let mut q = Query::new();
+/// q.add("a", "1");
+/// assert_eq!(q.get_line("a"), Some("1".to_string()));
+///
+/// let (_, parsed) = Query::parse("foo=bar").unwrap();
+/// assert_eq!(parsed.get("foo"), Some(&"bar".to_string()));
+/// ```
 pub struct Query {
     data: Dictionary<String>,
 }
@@ -372,7 +387,6 @@ impl Display for Request {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -382,7 +396,7 @@ mod tests {
         let query1 = "simple_query";
         let query2 = "variable=value";
         let query3 = "array[]=value&array[]=value2";
-        
+
         let (_, query) = Query::parse(query1).unwrap();
         assert_eq!(query.data.len(), 1);
         assert_eq!(query.get("simple_query"), Some(&"".to_string()));
@@ -390,16 +404,16 @@ mod tests {
         let (_, query) = Query::parse(query2).unwrap();
         assert_eq!(query.data.len(), 1);
         assert_eq!(query.get("variable"), Some(&"value".to_string()));
-        
+
         let (_, query) = Query::parse(query3).unwrap();
         assert_eq!(query.data.len(), 1);
         assert_eq!(query.get("array[]"), Some(&"value2".to_string()));
-        
+
         let query1 = "simple_query#fragment";
         let query2 = "variable=value#fragment";
         let query3 = "array[]=value&array[]=value2#fragment";
         let query4 = "map[a]=value1&map[b]=value2#fragment";
-        
+
         let (_, query) = Query::parse(query1).unwrap();
         assert_eq!(query.data.len(), 1);
         assert_eq!(query.get("simple_query"), Some(&"".to_string()));
@@ -466,7 +480,13 @@ mod tests {
 
     #[test]
     fn test_request_methods() {
-        let uri = Uri::new("http".into(), Authority::new("host".into(), None, None, None), Path::new("/".into(), None), Query::new(), None);
+        let uri = Uri::new(
+            "http".into(),
+            Authority::new("host".into(), None, None, None),
+            Path::new("/".into(), None),
+            Query::new(),
+            None,
+        );
         let req = Request {
             method: Method::Get,
             target: uri.clone(),
@@ -476,7 +496,13 @@ mod tests {
         assert_eq!(req.get_method(), Method::Get);
         let req2 = req.clone().with_method(Method::Post);
         assert_eq!(req2.get_method(), Method::Post);
-        let uri2 = Uri::new("http".into(), Authority::new("example".into(), None, None, None), Path::new("/".into(), None), Query::new(), None);
+        let uri2 = Uri::new(
+            "http".into(),
+            Authority::new("example".into(), None, None, None),
+            Path::new("/".into(), None),
+            Query::new(),
+            None,
+        );
         let req3 = req2.with_uri(uri2, true);
         assert_eq!(req3.get_header_line("Host"), Some("example".to_string()));
         assert!(req3.get_target().contains("http://example"));

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -50,7 +50,7 @@ pub enum Status {
     /// 304
     NotModified,
     /// 305
-    /// 
+    ///
     /// Deprecated, see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status#305_use_proxy
     UseProxy,
     /// 307
@@ -459,9 +459,9 @@ impl Parsable for Status {
         use nom::Parser;
 
         let (input, code) = digit1(input)?;
-        let code = code
-            .parse::<u16>()
-            .map_err(|_| nom::Err::Failure(nom::error::Error::new(code, nom::error::ErrorKind::Fail)))?;
+        let code = code.parse::<u16>().map_err(|_| {
+            nom::Err::Failure(nom::error::Error::new(code, nom::error::ErrorKind::Fail))
+        })?;
         let from_code = Status::from_code(code);
         let mut reason = None;
         let (mut input, _) = space0(input)?;
@@ -475,7 +475,10 @@ impl Parsable for Status {
         }
 
         if matches!(from_code, Status::Custom(_, ref r) if r.is_empty()) {
-            return Ok((input, Status::Custom(code, reason.unwrap_or_default().to_string())));
+            return Ok((
+                input,
+                Status::Custom(code, reason.unwrap_or_default().to_string()),
+            ));
         }
 
         if let Some(reason_phrase) = reason {
@@ -487,8 +490,6 @@ impl Parsable for Status {
         Ok((input, from_code))
     }
 }
-
-
 
 /// Behaviour shared by HTTP response types.
 pub trait ResponseTrait: MessageTrait {
@@ -505,6 +506,20 @@ pub trait ResponseTrait: MessageTrait {
 }
 
 #[derive(Debug, Clone)]
+/// Parsed HTTP response message.
+///
+/// The [`Response`] type wraps a [`Status`] and a [`Message`] carrying headers
+/// and body.  It implements [`ResponseTrait`] allowing high level access to the
+/// status code and helper methods for working with headers or the body.
+///
+/// # Examples
+/// ```
+/// use hermes::http::{Headers, ResponseFactory, Version, Status, ResponseTrait};
+///
+/// let factory = ResponseFactory::version(Version::Http1_1);
+/// let resp = factory.with_status(Status::OK, Headers::new());
+/// assert!(resp.to_string().starts_with("HTTP/1.1 200"));
+/// ```
 pub struct Response {
     pub status: Status,
     pub message: Message,
@@ -611,8 +626,6 @@ impl Display for Response {
         write!(f, "{}", self.message.raw())
     }
 }
-
-
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,15 @@
+//! Core library exposing HTTP primitives, an asynchronous client and server.
+//!
+//! The crate is organized in a few top level modules:
+//! - [`http`] re-exports the types used to parse and build HTTP messages.
+//! - [`client`] provides a minimal asynchronous HTTP client.
+//! - [`server`] contains an extremely small asynchronous server used in
+//!   examples and tests.
+//!
+//! The [`concepts`] module houses utility traits and data structures shared
+//! across the crate.
+
+pub mod client;
 pub mod concepts;
 pub mod http;
 pub mod server;
-pub mod client;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,9 +1,22 @@
-use tokio::net::{TcpListener, TcpStream};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use crate::http::{Headers, Request, ResponseFactory, Status, Version};
 use crate::concepts::Parsable;
+use crate::http::{Headers, Request, ResponseFactory, Status, Version};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
 
 /// Simple asynchronous TCP server handling HTTP requests.
+///
+/// # Examples
+///
+/// ```no_run
+/// use hermes::server::Server;
+///
+/// # tokio_test::block_on(async {
+/// let server = Server::new("127.0.0.1:8080");
+/// // This will block forever handling incoming connections
+/// // and therefore is marked as `no_run` in the documentation.
+/// // server.run().await.unwrap();
+/// # })
+/// ```
 pub struct Server {
     address: String,
 }


### PR DESCRIPTION
## Summary
- add crate level docs
- document HTTP module and types
- show how to use the async client and server
- include a new dev-dependency for doc tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684bb50ab6fc832f95781cdd68a5e8fd