### PR TITLE
Improve hermes-client CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,11 @@ In this version, the API will not change a lot, but it will grow very fast.
 
 * Finalize the routing system.
 
-### 0.1.1 (todo)
+### 0.1.1 (unreleased)
 
 * Enhance the client:
-  ```
-  Option for client request:
-  -h --header
-  add a header.
-  
-  syntax: client [-- options] <METHOD> <URL> [<BODY>]
-  ```
+  - New syntax `hermes-client [OPTIONS] <METHOD> <URL> [<BODY>]`.
+  - Add `-H/--header` option to specify headers multiple times.
 * Write a test: Test the server with multiple connections.
 * Refactor the client and server structures to be real objects.
 * Prototype a routing system.

--- a/src/bin/hermes-client.rs
+++ b/src/bin/hermes-client.rs
@@ -1,5 +1,7 @@
 use clap::{Arg, ArgAction, Command};
 use hermes::client::Client;
+use hermes::concepts::Parsable;
+use hermes::http::{Headers, Method, RequestFactory, Uri, Version};
 
 /// Version of the `hermes` crate used to build this binary.
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -18,19 +20,69 @@ async fn main() -> std::io::Result<()> {
                 .help("Print version information"),
         )
         .arg(
-            Arg::new("uri")
-                .value_name("URI")
-                .help("Destination URI")
+            Arg::new("header")
+                .short('H')
+                .long("header")
+                .value_name("HEADER")
+                .action(ArgAction::Append)
+                .help("Add a header"),
+        )
+        .arg(
+            Arg::new("method")
+                .value_name("METHOD")
+                .help("HTTP method")
                 .required(true),
+        )
+        .arg(
+            Arg::new("url")
+                .value_name("URL")
+                .help("Destination URL")
+                .required(true),
+        )
+        .arg(
+            Arg::new("body")
+                .value_name("BODY")
+                .help("Request body")
+                .required(false),
         )
         .get_matches();
 
+    let method_str = matches
+        .get_one::<String>("method")
+        .expect("method argument missing");
+    let (_, method) = Method::parse(method_str)
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid method"))?;
+
     let url = matches
-        .get_one::<String>("uri")
-        .expect("URI argument missing");
-    
-    println!("Sending request to {}", url);
-    let response = Client::get(url).await?;
+        .get_one::<String>("url")
+        .expect("URL argument missing");
+
+    let body = matches
+        .get_one::<String>("body")
+        .cloned()
+        .unwrap_or_default();
+
+    let mut headers = Headers::new();
+    let (_, uri) = Uri::parse(url)
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid url"))?;
+    headers.insert("Host", &[uri.authority.host.clone()]);
+
+    if let Some(values) = matches.get_many::<String>("header") {
+        for h in values {
+            let (_, (name, vals)) = Headers::parse_header(h).map_err(|_| {
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid header")
+            })?;
+            headers.insert(&name, &vals);
+        }
+    }
+
+    println!("Sending {} request to {}", method, url);
+    let factory = RequestFactory::version(Version::Http1_1);
+    let request = factory.build(method, uri, headers, &body);
+    let host = request.target.authority.host.clone();
+    let port = request.target.authority.port.unwrap_or(80);
+    let mut client = Client::new(host, port).await;
+    let response = client.send(request).await?;
     println!("{}", response);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- extend hermes-client command syntax to `hermes-client [OPTIONS] <METHOD> <URL> [<BODY>]`
- allow multiple `-H/--header` options
- document new CLI behaviour in CHANGELOG

## Testing
- `cargo fmt --all`
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_684c0ccab094832fac2393ca550a3fea