### PR TITLE
Update docs for new HTTP services module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ In this version, the API will not change a lot, but it will grow very fast.
 ### 0.1.2 (unreleased)
 
 * Finalize the routing system.
+* Move the HTTP client and server under the `http::services` namespace.
 
 ### 0.1.1
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ framework capable of replacing typical PHP stacks.
 
 - Utilities for parsing and generating HTTP messages exposed under the `http`
   module.
-- A minimal asynchronous client for performing requests.
-- A lightweight asynchronous server used in examples and tests.
+- A minimal asynchronous client for performing requests, available under
+  the `http::services` module.
+- A lightweight asynchronous server used in examples and tests, also under
+  `http::services`.
 - A simple router and `Controller` trait to handle incoming requests.
 
 ## Building

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,10 @@
 //! Core library exposing HTTP primitives, an asynchronous client and server.
 //!
-//! The crate is organized in a few top level modules:
-//! - [`cycle`] re-exports the types used to parse and build HTTP messages.
-//! - [`client`] provides a minimal asynchronous HTTP client.
-//! - [`server`] contains an extremely small asynchronous server used in
-//!   examples and tests.
-//!
-//! The [`concepts`] module houses utility traits and data structures shared
-//! across the crate.
+//! The crate is organised in a few top level modules:
+//! - [`http`] exposes all HTTP primitives. The [`http::services`] module
+//!   contains the asynchronous client and server used in examples and tests.
+//! - [`concepts`] houses utility traits and data structures shared across the
+//!   crate.
 
 pub mod concepts;
 pub mod http;


### PR DESCRIPTION
## Summary
- clarify module layout in `lib.rs`
- mention new `http::services` location in README
- add changelog entry about module reorganisation

## Testing
- `cargo fmt -- --check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684cbab990d4832f882b03c5422869f6