### PR TITLE
Add YAML formatter and documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +191,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -198,8 +210,20 @@ version = "0.1.2"
 dependencies = [
  "clap",
  "nom",
+ "serde_json",
+ "serde_yaml",
  "tokio",
  "tokio-test",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -207,6 +231,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
@@ -337,10 +367,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -442,6 +523,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ clap = { version = "4.5", features = ["derive"] }
 
 [dev-dependencies]
 tokio-test = "0.4"
+serde_json = "1"
+serde_yaml = "0.9"

--- a/src/concepts/value.rs
+++ b/src/concepts/value.rs
@@ -1,3 +1,9 @@
+//! Representation of loosely typed values and associated formatters.
+//!
+//! The [`Value`] enum can model typical JSON or YAML compatible values. It is
+//! accompanied by the [`ValueFormatter`] trait which allows serialising a
+//! `Value` into various textual formats.
+
 use crate::concepts::Dictionary;
 
 #[derive(Debug, Clone)]
@@ -17,3 +23,4 @@ pub trait ValueFormatter {
 }
 
 pub mod json;
+pub mod yaml;

--- a/src/concepts/value/json.rs
+++ b/src/concepts/value/json.rs
@@ -1,3 +1,8 @@
+//! JSON formatter for [`Value`].
+//!
+//! This module defines [`JsonFormatter`], a basic formatter converting a
+//! [`Value`] into its JSON string representation.
+
 use crate::concepts::value::{Value, ValueFormatter};
 
 pub struct JsonFormatter;
@@ -32,5 +37,55 @@ impl ValueFormatter for JsonFormatter {
                 s
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::concepts::Dictionary;
+    use serde_json::json;
+
+    #[test]
+    fn test_basic_types() {
+        let f = JsonFormatter;
+        assert_eq!(f.format(Value::Null), "null");
+        assert_eq!(f.format(Value::Bool(true)), "true");
+        assert_eq!(f.format(Value::Int(3)), "3");
+        assert_eq!(f.format(Value::String("a".to_string())), "\"a\"");
+    }
+
+    #[test]
+    fn test_array_and_dict() {
+        let f = JsonFormatter;
+        let arr = Value::Array(vec![Value::Int(1), Value::Int(2)]);
+        assert_eq!(f.format(arr), "[1,2]");
+
+        let mut d = Dictionary::new();
+        d.insert("k".to_string(), Value::Bool(false));
+        assert_eq!(f.format(Value::Dictionary(d)), "{\"k\": false}");
+    }
+
+    #[test]
+    fn test_nested_dictionary() {
+        let f = JsonFormatter;
+
+        let mut inner = Dictionary::new();
+        inner.insert("a".to_string(), Value::Int(1));
+        inner.insert("b".to_string(), Value::Int(2));
+
+        let mut outer = Dictionary::new();
+        outer.insert("inner".to_string(), Value::Dictionary(inner));
+        outer.insert("flag".to_string(), Value::Bool(true));
+
+        let mut root = Dictionary::new();
+        root.insert("outer".to_string(), Value::Dictionary(outer));
+        root.insert("count".to_string(), Value::Int(10));
+
+        let out = f.format(Value::Dictionary(root));
+
+        let parsed: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let expected = json!({"outer": {"inner": {"a": 1, "b": 2}, "flag": true}, "count": 10});
+        assert_eq!(parsed, expected);
     }
 }

--- a/src/concepts/value/yaml.rs
+++ b/src/concepts/value/yaml.rs
@@ -1,0 +1,115 @@
+//! YAML formatter for [`Value`].
+//!
+//! The formatter produces a minimal YAML representation. It is not intended
+//! to be fully compliant with all YAML features but is sufficient for tests
+//! and examples.
+
+use crate::concepts::value::{Value, ValueFormatter};
+
+pub struct YamlFormatter;
+
+impl YamlFormatter {
+    fn format_with_indent(&self, value: Value, indent: usize) -> String {
+        match value {
+            Value::Null => "null".to_string(),
+            Value::Bool(b) => if b { "true" } else { "false" }.to_string(),
+            Value::Int(i) => i.to_string(),
+            Value::Number(f) => f.to_string(),
+            Value::String(s) => format!("\"{}\"", s.replace('"', "\\\"")),
+            Value::Array(a) => {
+                let mut out = String::new();
+                for v in a {
+                    out.push_str(&" ".repeat(indent));
+                    out.push_str("- ");
+                    out.push_str(&self.format_with_indent(v, indent + 2));
+                    out.push('\n');
+                }
+                if out.ends_with('\n') {
+                    out.pop();
+                }
+                out
+            }
+            Value::Dictionary(d) => {
+                let mut out = String::new();
+                for (k, v) in d {
+                    out.push_str(&" ".repeat(indent));
+                    out.push_str(&format!("{}: ", k));
+                    match v {
+                        Value::Array(_) | Value::Dictionary(_) => {
+                            out.push('\n');
+                            out.push_str(&self.format_with_indent(v, indent + 2));
+                            out.push('\n');
+                        }
+                        _ => {
+                            out.push_str(&self.format_with_indent(v, indent));
+                            out.push('\n');
+                        }
+                    }
+                }
+                if out.ends_with('\n') {
+                    out.pop();
+                }
+                out
+            }
+        }
+    }
+}
+
+impl ValueFormatter for YamlFormatter {
+    fn format(&self, value: Value) -> String {
+        self.format_with_indent(value, 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::concepts::Dictionary;
+    use serde_yaml::Value as YamlValue;
+
+    #[test]
+    fn test_scalar() {
+        let f = YamlFormatter;
+        assert_eq!(f.format(Value::Bool(false)), "false");
+    }
+
+    #[test]
+    fn test_array() {
+        let f = YamlFormatter;
+        let arr = Value::Array(vec![Value::Int(1), Value::Int(2)]);
+        assert_eq!(f.format(arr), "- 1\n- 2");
+    }
+
+    #[test]
+    fn test_dictionary() {
+        let f = YamlFormatter;
+        let mut d = Dictionary::new();
+        d.insert("a".to_string(), Value::Int(1));
+        assert_eq!(f.format(Value::Dictionary(d)), "a: 1");
+    }
+
+    #[test]
+    fn test_nested_dictionary() {
+        let f = YamlFormatter;
+
+        let mut inner = Dictionary::new();
+        inner.insert("a".to_string(), Value::Int(1));
+        inner.insert("b".to_string(), Value::Int(2));
+
+        let mut outer = Dictionary::new();
+        outer.insert("inner".to_string(), Value::Dictionary(inner));
+        outer.insert("flag".to_string(), Value::Bool(true));
+
+        let mut root = Dictionary::new();
+        root.insert("outer".to_string(), Value::Dictionary(outer));
+        root.insert("count".to_string(), Value::Int(10));
+
+        let out = f.format(Value::Dictionary(root));
+
+        let parsed: YamlValue = serde_yaml::from_str(&out).unwrap();
+        let expected: YamlValue =
+            serde_yaml::from_str("outer:\n  inner:\n    a: 1\n    b: 2\n  flag: true\ncount: 10")
+                .unwrap();
+        assert_eq!(parsed, expected);
+    }
+}


### PR DESCRIPTION
## Summary
- document `value` and `json` modules
- introduce documented `yaml` module with a simple formatter
- provide unit tests for JSON and YAML formatters
- add more tests with nested dictionaries

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685013ed0608832fbcc0293aaa34a620