### PR TITLE
Improve documentation and fix compile warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ At this stage the crate offers utilities for parsing and generating HTTP
 messages. All core types are available under the `http` module. It also ships
 with a minimal asynchronous client and server used in the tests and examples.
 
+## Quick example
+
+```rust,no_run
+use hermes::http::services::client::Client;
+use hermes::http::ResponseTrait;
+
+# tokio_test::block_on(async {
+let resp = Client::get("http://example.com").await.unwrap();
+println!("Status: {}", resp.code());
+# });
+```
+
 ## Roadmap
 
 The project will evolve into a complete backend framework. Upcoming milestones

--- a/src/concepts/process.rs
+++ b/src/concepts/process.rs
@@ -1,13 +1,43 @@
+//! Abstractions for running a small application lifecycle.
+//!
+//! The [`Process`] trait models a task that can be initialised, executed and
+//! finalised. [`Application`] is a simple wrapper holding configuration and a
+//! boxed kernel implementing [`Process`].
 
+/// Basic process executed by the [`Application`] runtime.
+///
+/// The trait defines three lifecycle hooks:
+/// - [`Process::initialize`] prepares resources.
+/// - [`Process::execute`] performs the main logic.
+/// - [`Process::finalize`] cleans up after execution.
+///
+/// The [`Process::run`] helper executes these steps in order.
+///
+/// # Example
+/// ```
+/// use hermes::concepts::process::Process;
+///
+/// struct Task;
+/// impl Process<()> for Task {
+///     fn execute(&mut self) -> Result<(), String> { Ok(()) }
+/// }
+///
+/// let mut task = Task;
+/// assert!(task.run().is_ok());
+/// ```
 pub trait Process<R = (), E = String> {
+    /// Perform the main logic and return a result.
     fn execute(&mut self) -> Result<R, E>;
+    /// Prepare the process before [`execute`](Process::execute) runs.
     fn initialize(&mut self) -> Result<(), E> {
         Ok(())
     }
+    /// Called after [`execute`](Process::execute) completes to release resources.
     fn finalize(&mut self) -> Result<(), E> {
         Ok(())
     }
 
+    /// Execute `initialize`, `execute` and `finalize` in sequence.
     fn run(&mut self) -> Result<R, E> {
         self.initialize()?;
         let result = self.execute()?;
@@ -16,14 +46,17 @@ pub trait Process<R = (), E = String> {
     }
 }
 
+/// A boxed [`Process`] used as the entry point of an application.
 pub type Kernel<E> = dyn Process<(), E>;
 
+/// Minimal wrapper executing a [`Kernel`] with some configuration.
 pub struct Application<C, E> {
     pub config: C,
     kernel: Box<Kernel<E>>,
 }
 
 impl<C, E> Application<C, E> {
+    /// Create a new application wrapping the given kernel and configuration.
     pub fn new(config: C, kernel: &Kernel<E>) -> Self
     where
         Kernel<E>: Clone,

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,13 +1,18 @@
+//! Public HTTP API of the framework.
+//!
+//! This module re-exports the main types used to build requests and responses,
+//! along with minimal client and server implementations.
+
 pub mod cycle;
 
-pub use cycle::uri::*;
+pub use cycle::factory::*;
 pub use cycle::message::*;
 pub use cycle::request::*;
 pub use cycle::response::*;
-pub use cycle::factory::*;
+pub use cycle::uri::*;
 
 pub mod error;
-pub mod services;
 pub mod routing;
+pub mod services;
 
 pub use error::*;

--- a/src/http/routing/controller.rs
+++ b/src/http/routing/controller.rs
@@ -263,7 +263,7 @@ mod tests {
                 req: &mut Request,
                 next: &mut dyn Controller<(), Request, Response>,
             ) -> Response {
-                let mut res = next.handle(ctx, req);
+                let res = next.handle(ctx, req);
                 self.0.lock().unwrap().0.push("after");
                 res
             }

--- a/src/http/services.rs
+++ b/src/http/services.rs
@@ -1,3 +1,4 @@
+//! Minimal asynchronous client and server implementations.
 
 pub mod client;
 


### PR DESCRIPTION
## Summary
- add a quick example in the README
- document the lifecycle helpers in `concepts::process`
- document the HTTP module and services
- fix a mutable variable warning in tests

## Testing
- `cargo fmt -- --check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68589d0067bc832f8c00e3671264a17c