### PR TITLE
Improve doc tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ At this stage the crate offers utilities for parsing and generating HTTP
 messages. All core types are available under the `http` module. It also ships
 with a minimal asynchronous client and server used in the tests and examples.
 
+## Quick example
+
+```rust
+use hermes::http::services::client::Client;
+use hermes::http::ResponseTrait;
+
+# tokio_test::block_on(async {
+let resp = Client::get("http://example.com").await.unwrap();
+println!("Status: {}", resp.code());
+# });
+```
+
 ## Roadmap
 
 The project will evolve into a complete backend framework. Upcoming milestones

--- a/src/concepts/process.rs
+++ b/src/concepts/process.rs
@@ -1,13 +1,43 @@
+//! Abstractions for running a small application lifecycle.
+//!
+//! The [`Process`] trait models a task that can be initialised, executed and
+//! finalised. [`Application`] is a simple wrapper holding configuration and a
+//! boxed kernel implementing [`Process`].
 
+/// Basic process executed by the [`Application`] runtime.
+///
+/// The trait defines three lifecycle hooks:
+/// - [`Process::initialize`] prepares resources.
+/// - [`Process::execute`] performs the main logic.
+/// - [`Process::finalize`] cleans up after execution.
+///
+/// The [`Process::run`] helper executes these steps in order.
+///
+/// # Example
+/// ```
+/// use hermes::concepts::process::Process;
+///
+/// struct Task;
+/// impl Process<()> for Task {
+///     fn execute(&mut self) -> Result<(), String> { Ok(()) }
+/// }
+///
+/// let mut task = Task;
+/// assert!(task.run().is_ok());
+/// ```
 pub trait Process<R = (), E = String> {
+    /// Perform the main logic and return a result.
     fn execute(&mut self) -> Result<R, E>;
+    /// Prepare the process before [`execute`](Process::execute) runs.
     fn initialize(&mut self) -> Result<(), E> {
         Ok(())
     }
+    /// Called after [`execute`](Process::execute) completes to release resources.
     fn finalize(&mut self) -> Result<(), E> {
         Ok(())
     }
 
+    /// Execute `initialize`, `execute` and `finalize` in sequence.
     fn run(&mut self) -> Result<R, E> {
         self.initialize()?;
         let result = self.execute()?;
@@ -16,21 +46,37 @@ pub trait Process<R = (), E = String> {
     }
 }
 
+/// A boxed [`Process`] used as the entry point of an application.
 pub type Kernel<E> = dyn Process<(), E>;
 
+/// Minimal wrapper executing a [`Kernel`] with some configuration.
+///
+/// # Example
+/// ```
+/// use hermes::concepts::process::{Application, Process};
+///
+/// struct Hello;
+/// impl Process<()> for Hello {
+///     fn execute(&mut self) -> Result<(), String> { Ok(()) }
+/// }
+///
+/// let mut app = Application::new("config", Hello);
+/// assert!(app.run().is_ok());
+/// ```
 pub struct Application<C, E> {
     pub config: C,
     kernel: Box<Kernel<E>>,
 }
 
 impl<C, E> Application<C, E> {
-    pub fn new(config: C, kernel: &Kernel<E>) -> Self
+    /// Create a new application wrapping the given kernel and configuration.
+    pub fn new<K>(config: C, kernel: K) -> Self
     where
-        Kernel<E>: Clone,
+        K: Process<(), E> + 'static,
     {
         Self {
             config,
-            kernel: Box::new(kernel.clone()),
+            kernel: Box::new(kernel),
         }
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,13 +1,18 @@
+//! Public HTTP API of the framework.
+//!
+//! This module re-exports the main types used to build requests and responses,
+//! along with minimal client and server implementations.
+
 pub mod cycle;
 
-pub use cycle::uri::*;
+pub use cycle::factory::*;
 pub use cycle::message::*;
 pub use cycle::request::*;
 pub use cycle::response::*;
-pub use cycle::factory::*;
+pub use cycle::uri::*;
 
 pub mod error;
-pub mod services;
 pub mod routing;
+pub mod services;
 
 pub use error::*;

--- a/src/http/routing/router.rs
+++ b/src/http/routing/router.rs
@@ -100,6 +100,32 @@ pub struct RouteMatch<'a, Ctx, Req: RequestTrait = Request, Res: ResponseTrait =
 }
 
 /// Collection of [`Route`]s able to select one for a given request.
+///
+/// # Example
+/// ```
+/// use hermes::http::routing::router::{Router, Route};
+/// use hermes::http::routing::controller::Controller;
+/// use hermes::http::{Headers, Method, RequestFactory, ResponseFactory, Status, Version, Response, Request, Uri, Authority, Path, Query, ResponseTrait};
+///
+/// struct Ping;
+/// impl Controller<(), Request, Response> for Ping {
+///     fn handle(&mut self, _: &(), _: &mut Request) -> Response {
+///         ResponseFactory::version(Version::Http1_1).with_status(Status::OK, Headers::new())
+///     }
+/// }
+///
+/// let mut router = Router::new();
+/// router.add_route(Route::new(
+///     "/ping",
+///     vec![Method::Get],
+///     Headers::new(),
+///     Box::new(Ping),
+/// ));
+/// let uri = Uri::new(String::new(), Authority::default(), Path::new("/ping".to_string(), None), Query::new(), None);
+/// let mut req = RequestFactory::version(Version::Http1_1).build(Method::Get, uri, Headers::new(), "");
+/// let resp = router.handle_request(&(), &mut req).unwrap();
+/// assert_eq!(resp.status(), Status::OK);
+/// ```
 #[derive(Debug, Default)]
 pub struct Router<Ctx, Req: RequestTrait = Request, Res: ResponseTrait = Response> {
     routes: Vec<Route<Ctx, Req, Res>>,

--- a/src/http/services.rs
+++ b/src/http/services.rs
@@ -1,3 +1,4 @@
+//! Minimal asynchronous client and server implementations.
 
 pub mod client;
 

--- a/src/http/services/client.rs
+++ b/src/http/services/client.rs
@@ -9,12 +9,21 @@ use tokio::net::TcpStream;
 ///
 /// # Examples
 ///
-/// ```no_run
-/// use hermes::http::services::client::Client;
-/// use hermes::http::ResponseTrait;
+/// ```
+/// use hermes::http::services::{client::Client, server::Server};
+/// use hermes::http::{ResponseTrait, Status};
 /// # tokio_test::block_on(async {
-/// let response = Client::get("http://example.com").await.unwrap();
-/// println!("{}", response.code());
+/// let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+/// let port = listener.local_addr().unwrap().port();
+/// drop(listener);
+/// let addr = format!("127.0.0.1:{port}");
+/// let server = Server::new(&addr);
+/// let handle = tokio::spawn(async move { let _ = server.run().await; });
+/// tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+/// let url = format!("http://{}", addr);
+/// let response = Client::get(&url).await.unwrap();
+/// assert_eq!(response.status(), Status::NoContent);
+/// handle.abort();
 /// # })
 /// ```
 pub struct Client {

--- a/src/http/services/server.rs
+++ b/src/http/services/server.rs
@@ -7,14 +7,21 @@ use tokio::net::{TcpListener, TcpStream};
 ///
 /// # Examples
 ///
-/// ```no_run
-/// use hermes::http::services::server::Server;
-///
+/// ```
+/// use hermes::http::services::{server::Server, client::Client};
+/// use hermes::http::{Status, ResponseTrait};
 /// # tokio_test::block_on(async {
-/// let server = Server::new("127.0.0.1:8080");
-/// // This will block forever handling incoming connections
-/// // and therefore is marked as `no_run` in the documentation.
-/// // server.run().await.unwrap();
+/// let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+/// let port = listener.local_addr().unwrap().port();
+/// drop(listener);
+/// let addr = format!("127.0.0.1:{port}");
+/// let server = Server::new(&addr);
+/// let handle = tokio::spawn(async move { let _ = server.run().await; });
+/// tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+/// let url = format!("http://{}", addr);
+/// let resp = Client::get(&url).await.unwrap();
+/// assert_eq!(resp.status(), Status::NoContent);
+/// handle.abort();
 /// # })
 /// ```
 #[derive(Clone)]


### PR DESCRIPTION
## Summary
- make the README quick example runnable
- update `Process` and `Application` examples
- adapt client/server docs to run a short local server
- run router and mediator examples as tests

## Testing
- `cargo fmt -- --check`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68589d0067bc832f8c00e3671264a17c