### PR TITLE
Implement basic DI container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ In this version, the API will not change a lot, but it will grow very fast.
 * Fix host header preservation in `Request::with_uri`.
 * Reduce required Tokio features.
 * Standardize American English in documentation and update dependencies.
+* Introduce a simple dependency injection container.
 
 ### 0.1.1
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ framework capable of replacing typical PHP stacks.
   `http::services`.
 - A router with route groups and a `Controller` trait to handle incoming
   requests.
+- A simple dependency injection `Container` for sharing services with
+  controllers.
 
 ## Building
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@
 
 3. **Controllers and Dependency Injection**
     - ~~Define a trait or structure for controllers.~~
-    - Add a dependency injection container to create required instances (services, database access, etc.).
+    - ~~Add a dependency injection container to create required instances (services, database access, etc.).~~
 
 4. **Middleware (Request Pipeline)**
     - ~~Allow adding middleware executed before or after controllers (authentication, logging).~~

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,0 +1,70 @@
+//! Dependency injection container.
+//!
+//! The `Container` stores services indexed by their type and returns them as
+//! shared references. Services are registered as singletons using
+//! [`register`]. Controllers can receive the container as context to retrieve
+//! required dependencies.
+//!
+//! # Example
+//!
+//! ```
+//! use hermes::container::Container;
+//! use hermes::http::routing::router::{Route, Router};
+//! use hermes::http::{Headers, Method, Request, Response, ResponseFactory, Status, Version};
+//!
+//! fn ping(ctx: &Container, _req: &mut Request) -> Response {
+//!     let value = ctx.resolve::<u32>().unwrap();
+//!     assert_eq!(*value, 42);
+//!     ResponseFactory::version(Version::Http1_1).with_status(Status::OK, Headers::new())
+//! }
+//!
+//! let mut container = Container::new();
+//! container.register(42u32);
+//!
+//! let mut router: Router<Container> = Router::new();
+//! router.add_route(Route::new("/ping", vec![Method::Get], Headers::new(), Box::new(ping)));
+//! ```
+//!
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Simple service container holding singleton instances.
+#[derive(Default)]
+pub struct Container {
+    services: HashMap<TypeId, Arc<dyn Any + Send + Sync>>,
+}
+
+impl Container {
+    /// Create an empty container.
+    pub fn new() -> Self {
+        Self {
+            services: HashMap::new(),
+        }
+    }
+
+    /// Register a service instance of type `T`.
+    pub fn register<T: Any + Send + Sync>(&mut self, service: T) {
+        self.services.insert(TypeId::of::<T>(), Arc::new(service));
+    }
+
+    /// Retrieve a service of type `T` if present.
+    pub fn resolve<T: Any + Send + Sync>(&self) -> Option<Arc<T>> {
+        self.services
+            .get(&TypeId::of::<T>())
+            .and_then(|s| s.clone().downcast::<T>().ok())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_and_resolve() {
+        let mut c = Container::new();
+        c.register::<u32>(1);
+        let value = c.resolve::<u32>().unwrap();
+        assert_eq!(*value, 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,5 @@
 //!   crate.
 
 pub mod concepts;
+pub mod container;
 pub mod http;


### PR DESCRIPTION
## Summary
- add a simple `Container` for dependency injection
- document it with an example showing controllers
- export the new module
- mention the container in README features
- mark the roadmap step as completed
- log the addition in the changelog

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6859b23a9164832f9fa0a2684b0508f1