### PR TITLE
Implement named instances in DI container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ In this version, the API will not change a lot, but it will grow very fast.
 * Reduce required Tokio features.
 * Standardize American English in documentation and update dependencies.
 * Introduce a simple dependency injection container.
+* Allow registering multiple instances of the same type in the container.
+* Name each instance with a string to retrieve a specific one.
 
 ### 0.1.1
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ framework capable of replacing typical PHP stacks.
   `http::services`.
 - A router with route groups and a `Controller` trait to handle incoming
   requests.
-- A simple dependency injection `Container` for sharing services with
-  controllers.
+- A simple dependency injection `Container` supporting multiple named instances
+  of a type for sharing services with controllers.
 
 ## Building
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,6 +11,7 @@
 3. **Controllers and Dependency Injection**
     - ~~Define a trait or structure for controllers.~~
     - ~~Add a dependency injection container to create required instances (services, database access, etc.).~~
+    - Support multiple named instances of the same type within the container.
 
 4. **Middleware (Request Pipeline)**
     - ~~Allow adding middleware executed before or after controllers (authentication, logging).~~

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,9 +1,10 @@
 //! Dependency injection container.
 //!
 //! The `Container` stores services indexed by their type and returns them as
-//! shared references. Services are registered as singletons using
-//! [`register`]. Controllers can receive the container as context to retrieve
-//! required dependencies.
+//! shared references. Multiple instances of the same type can be registered and
+//! retrieved. Each instance is associated with a name to allow resolving a
+//! particular service. Controllers can receive the container as context to
+//! obtain the required dependencies.
 //!
 //! # Example
 //!
@@ -13,13 +14,13 @@
 //! use hermes::http::{Headers, Method, Request, Response, ResponseFactory, Status, Version};
 //!
 //! fn ping(ctx: &Container, _req: &mut Request) -> Response {
-//!     let value = ctx.resolve::<u32>().unwrap();
+//!     let value = ctx.resolve_named::<u32>("answer").unwrap();
 //!     assert_eq!(*value, 42);
 //!     ResponseFactory::version(Version::Http1_1).with_status(Status::OK, Headers::new())
 //! }
 //!
 //! let mut container = Container::new();
-//! container.register(42u32);
+//! container.register_named("answer", 42u32);
 //!
 //! let mut router: Router<Container> = Router::new();
 //! router.add_route(Route::new("/ping", vec![Method::Get], Headers::new(), Box::new(ping)));
@@ -29,10 +30,10 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// Simple service container holding singleton instances.
+/// Simple service container holding one or more instances per type.
 #[derive(Default)]
 pub struct Container {
-    services: HashMap<TypeId, Arc<dyn Any + Send + Sync>>,
+    services: HashMap<TypeId, HashMap<String, Arc<dyn Any + Send + Sync>>>,
 }
 
 impl Container {
@@ -43,16 +44,59 @@ impl Container {
         }
     }
 
-    /// Register a service instance of type `T`.
+    /// Register a service instance of type `T` with a custom name.
+    pub fn register_named<T: Any + Send + Sync>(&mut self, name: impl Into<String>, service: T) {
+        self.services
+            .entry(TypeId::of::<T>())
+            .or_insert_with(HashMap::new)
+            .insert(name.into(), Arc::new(service));
+    }
+
+    /// Register a service instance of type `T` using the default name `"default"`.
     pub fn register<T: Any + Send + Sync>(&mut self, service: T) {
-        self.services.insert(TypeId::of::<T>(), Arc::new(service));
+        self.register_named("default", service);
     }
 
     /// Retrieve a service of type `T` if present.
     pub fn resolve<T: Any + Send + Sync>(&self) -> Option<Arc<T>> {
         self.services
             .get(&TypeId::of::<T>())
-            .and_then(|s| s.clone().downcast::<T>().ok())
+            .and_then(|map| {
+                map.get("default")
+                    .cloned()
+                    .or_else(|| map.values().next().cloned())
+            })
+            .and_then(|s| s.downcast::<T>().ok())
+    }
+
+    /// Retrieve a named service of type `T` if present.
+    pub fn resolve_named<T: Any + Send + Sync>(&self, name: &str) -> Option<Arc<T>> {
+        self.services
+            .get(&TypeId::of::<T>())
+            .and_then(|map| map.get(name).cloned())
+            .and_then(|s| s.downcast::<T>().ok())
+    }
+
+    /// Retrieve all services of type `T`.
+    ///
+    /// ```
+    /// use hermes::container::Container;
+    ///
+    /// let mut c = Container::new();
+    /// c.register_named::<u32>("one", 1);
+    /// c.register_named::<u32>("two", 2);
+    /// let values = c.resolve_all::<u32>();
+    /// assert_eq!(values.len(), 2);
+    /// ```
+    pub fn resolve_all<T: Any + Send + Sync>(&self) -> Vec<Arc<T>> {
+        self.services
+            .get(&TypeId::of::<T>())
+            .map(|map| {
+                map.values()
+                    .filter_map(|s| s.clone().downcast::<T>().ok())
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }
 
@@ -66,5 +110,28 @@ mod tests {
         c.register::<u32>(1);
         let value = c.resolve::<u32>().unwrap();
         assert_eq!(*value, 1);
+    }
+
+    #[test]
+    fn named_registration() {
+        let mut c = Container::new();
+        c.register_named::<u32>("first", 1);
+        c.register_named::<u32>("second", 2);
+        let one = c.resolve_named::<u32>("first").unwrap();
+        let two = c.resolve_named::<u32>("second").unwrap();
+        assert_eq!(*one, 1);
+        assert_eq!(*two, 2);
+    }
+
+    #[test]
+    fn multiple_instances() {
+        let mut c = Container::new();
+        c.register_named::<u32>("one", 1);
+        c.register_named::<u32>("two", 2);
+        let all = c.resolve_all::<u32>();
+        assert_eq!(all.len(), 2);
+        let mut values = all.iter().map(|v| **v).collect::<Vec<_>>();
+        values.sort();
+        assert_eq!(values, vec![1, 2]);
     }
 }

--- a/tests/controller_container.rs
+++ b/tests/controller_container.rs
@@ -1,0 +1,46 @@
+use hermes::container::Container;
+use hermes::http::routing::router::{Route, Router};
+use hermes::http::{
+    Authority, Headers, Message, MessageTrait, Method, Path, Query, Request, ResponseFactory,
+    Status, Uri, Version,
+};
+
+#[derive(Clone)]
+struct Config {
+    name: &'static str,
+}
+
+#[test]
+fn controller_uses_container() {
+    let mut container = Container::new();
+    container.register_named("conf", Config { name: "hermes" });
+
+    let mut router: Router<Container> = Router::new();
+    router.add_route(Route::new(
+        "/conf",
+        vec![Method::Get],
+        Headers::new(),
+        Box::new(|ctx: &Container, _req: &mut Request| {
+            let cfg = ctx.resolve_named::<Config>("conf").unwrap();
+            ResponseFactory::version(Version::Http1_1)
+                .with_status(Status::OK, Headers::new())
+                .with_body(cfg.name)
+        }),
+    ));
+
+    let uri = Uri::new(
+        String::new(),
+        Authority::default(),
+        Path::new("/conf".into(), None),
+        Query::new(),
+        None,
+    );
+    let mut req = Request {
+        method: Method::Get,
+        target: uri,
+        message: Message::v1_1(Headers::new(), String::new()),
+    };
+
+    let resp = router.handle_request(&container, &mut req).unwrap();
+    assert_eq!(resp.body(), "hermes");
+}


### PR DESCRIPTION
## Summary
- add `register_named` and `resolve_named` to `Container`
- store services in a map keyed by name
- update docs and roadmap to reflect named instances
- adjust tests and integration test for the new API

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6859b8323c08832f991931ef11fd2a03