### PR TITLE
Add structured session values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ In this version, the API will not change a lot, but it will grow very fast.
   default file-based implementation.
 * Document the default backend and customisation points in the roadmap and README.
 * Move the `session` module under `http` for better organisation.
+* Support storing `Value` objects in sessions and allow choosing a
+  `ValueFormatter` for the file-based backend (JSON by default).
+* Provide cookie parsing utilities and helpers to set cookies on responses.
+* Add `generate_id` to create secure session identifiers.
 
 ### 0.1.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bumpalo"
+version = "3.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +187,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +226,7 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "tokio-test",
+ "uuid",
 ]
 
 [[package]]
@@ -227,10 +252,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -254,7 +295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -275,6 +316,12 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -307,10 +354,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -460,10 +519,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-sys"
@@ -546,3 +683,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ tokio = { version = "1.*", features = [
     "time",
 ] }
 clap = { version = "4.*", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9.*"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tokio-test = "0.*"
-serde_json = "1"
-serde_yaml = "0.9.*"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ framework capable of replacing typical PHP stacks.
 - A simple dependency injection `Container` supporting multiple named instances
   of a type for sharing services with controllers.
 - Basic session handling backed by a file-based store with a pluggable
-  `SessionStore` trait available under the `http::session` module.
+  `SessionStore` trait. Session values use the `Value` type and are stored using
+  a configurable formatter (JSON by default) under the `http::session` module.
+  The module also exposes a `generate_id` helper to create secure session IDs.
+- Simple cookie parsing and response helpers available under the `http::cookie`
+  module.
 
 ## Building
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,9 @@
     - ~~Securely store session data using a file-based backend by default.
       Provide an interface so developers can plug in custom stores such as
       databases or key-value systems.~~
-    - Provide a clear API for reading/writing cookies and handling session persistence.
+    - ~~Provide a clear API for reading/writing cookies and handling session persistence.~~
+    - ~~Support structured session values through the `Value` type and allow choosing
+      a `ValueFormatter` for file-based storage (JSON by default).~~
 
 6. **Security**
     - Implement authentication mechanisms (Basic, tokens, sessions, OAuth).

--- a/src/concepts/value.rs
+++ b/src/concepts/value.rs
@@ -6,7 +6,7 @@
 
 use crate::concepts::Dictionary;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 /// Represents a generic JSON-like value used when parsing parameters.
 pub enum Value {
     Null,
@@ -20,6 +20,7 @@ pub enum Value {
 
 pub trait ValueFormatter {
     fn format(&self, value: Value) -> String;
+    fn parse(&self, input: &str) -> Option<Value>;
 }
 
 pub mod json;

--- a/src/http.rs
+++ b/src/http.rs
@@ -11,6 +11,7 @@ pub use cycle::request::*;
 pub use cycle::response::*;
 pub use cycle::uri::*;
 
+pub mod cookie;
 pub mod error;
 pub mod routing;
 pub mod services;

--- a/src/http/cookie.rs
+++ b/src/http/cookie.rs
@@ -1,0 +1,81 @@
+//! Simple utilities for working with HTTP cookies.
+//!
+//! The module provides a [`Cookie`] type and a [`CookieJar`] collection
+//! to parse and generate `Cookie` and `Set-Cookie` header values.
+
+use crate::concepts::Dictionary;
+
+/// Representation of a single HTTP cookie.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Cookie {
+    /// Name of the cookie.
+    pub name: String,
+    /// Value stored in the cookie.
+    pub value: String,
+}
+
+impl Cookie {
+    /// Create a new [`Cookie`] with the provided name and value.
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: value.into(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+/// Collection of cookies typically stored in the `Cookie` header.
+pub struct CookieJar {
+    cookies: Dictionary<String>,
+}
+
+impl CookieJar {
+    /// Create an empty [`CookieJar`].
+    pub fn new() -> Self {
+        Self {
+            cookies: Dictionary::new(),
+        }
+    }
+
+    /// Insert or update a cookie.
+    pub fn insert(&mut self, name: impl Into<String>, value: impl Into<String>) {
+        self.cookies.insert(name.into(), value.into());
+    }
+
+    /// Get a cookie value by name.
+    pub fn get(&self, name: &str) -> Option<&String> {
+        self.cookies.get(name)
+    }
+
+    /// Remove a cookie from the jar.
+    pub fn remove(&mut self, name: &str) {
+        self.cookies.remove(name);
+    }
+
+    /// Parse cookies from a `Cookie` header string.
+    pub fn parse(header: &str) -> Self {
+        let mut jar = Self::new();
+        for pair in header.split(';') {
+            let trimmed = pair.trim();
+            if let Some((n, v)) = trimmed.split_once('=') {
+                jar.insert(n.trim(), v.trim());
+            }
+        }
+        jar
+    }
+
+    /// Render the cookies as a `Cookie` header line.
+    pub fn to_header(&self) -> String {
+        self.cookies
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+
+    /// Iterate over stored cookie name/value pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &String)> {
+        self.cookies.iter()
+    }
+}

--- a/src/http/services/client.rs
+++ b/src/http/services/client.rs
@@ -1,7 +1,7 @@
 use crate::concepts::value::json::JsonFormatter;
 use crate::concepts::value::{Value, ValueFormatter};
 use crate::concepts::Parsable;
-use crate::http::{Headers, Method, Request, Response, Version};
+use crate::http::{Headers, Method, Request, RequestFactory, Response, Uri, Version};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
@@ -60,11 +60,11 @@ impl Client {
         headers: Headers,
         body: &str,
     ) -> std::io::Result<Response> {
-        let (_, uri) = crate::http::Uri::parse(url)
+        let (_, uri) = Uri::parse(url)
             .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid url"))?;
         let mut headers = headers;
         headers.insert("Host", &[uri.authority.host.clone()]);
-        let factory = crate::http::RequestFactory::version(Version::Http1_1);
+        let factory = RequestFactory::version(Version::Http1_1);
         let request = factory.build(method, uri, headers, body);
         let host = request.target.authority.host.clone();
         let port = request.target.authority.port.unwrap_or(80);


### PR DESCRIPTION
## Summary
- allow storing `Value` objects in sessions
- store session values through `ValueFormatter`
- support JSON or YAML parsing/formatting for sessions
- document session updates
- mark the structured session values step as complete in the roadmap
- add cookie utilities with parsing and response helpers
- replace fully qualified names with imports
- add utility to generate secure session IDs

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6859daa0a10c832fb1ccd37a14320fa4