### PR TITLE
Fix no_content status and add test

### DIFF
--- a/src/http/cycle/factory.rs
+++ b/src/http/cycle/factory.rs
@@ -407,7 +407,7 @@ impl ResponseFactory {
     /// assert_eq!(resp.body(), "");
     /// ```
     pub fn no_content(&self, headers: Headers) -> Response {
-        self.with_status(Status::OK, headers)
+        self.with_status(Status::NoContent, headers)
     }
     /// Create a 300 Multiple Choices response.
     ///
@@ -631,5 +631,12 @@ mod tests {
         };
         let resp = factory.unauthorized(www, Headers::new());
         assert_eq!(resp.status, Status::Unauthorized);
+    }
+
+    #[test]
+    fn test_no_content_status() {
+        let factory = ResponseFactory::version(Version::Http1_1);
+        let resp = factory.no_content(Headers::new());
+        assert_eq!(resp.status, Status::NoContent);
     }
 }


### PR DESCRIPTION
## Summary
- correct `ResponseFactory::no_content` to set a 204 status
- test that `no_content` returns `Status::NoContent`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685be897afd8832f81b3bd117db7bd99