### PR TITLE
Handle root slash in Uri display

### DIFF
--- a/src/http/cycle/factory.rs
+++ b/src/http/cycle/factory.rs
@@ -618,7 +618,7 @@ mod tests {
         );
         let resp = factory.moved_permanently(target.clone());
         assert_eq!(resp.status, Status::MovedPermanently);
-        assert!(resp.message.raw().contains("http://host//"));
+        assert!(resp.message.raw().contains("http://host/"));
 
         let resp = factory.ok(Headers::new(), "body".to_string());
         assert_eq!(resp.status, Status::OK);

--- a/src/http/cycle/uri.rs
+++ b/src/http/cycle/uri.rs
@@ -2,8 +2,8 @@
 use crate::concepts::{concat_if_both, Parsable};
 use crate::http::ParseError;
 use crate::http::Query;
+use nom::bytes::complete::take_while;
 use nom::bytes::complete::{tag, take_till, take_until};
-use nom::bytes::take_while;
 use nom::character::anychar;
 use nom::combinator::opt;
 use nom::multi::fold_many0;
@@ -317,7 +317,7 @@ impl Display for Uri {
             concat_if_both(&self.scheme, ":"),
             concat_if_both(
                 "//",
-                &if path.resource.is_empty() {
+                &if path.resource.is_empty() || path.resource.starts_with('/') {
                     self.authority()
                 } else {
                     concat_if_both(&self.authority(), "/")

--- a/tests/client_server.rs
+++ b/tests/client_server.rs
@@ -21,15 +21,17 @@ async fn test_client_server_parallel_requests() {
     // Give the server a moment to start listening
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-    // `Client::get` cannot parse URLs ending with a slash when a port is
-    // specified, so we omit the trailing `/` here.
     let url = format!("http://{}", address);
+    let url_with_slash = format!("{}/", url);
     let mut tasks = Vec::new();
     for _ in 0..5 {
-        let url = url.clone();
-        tasks.push(tokio::spawn(
-            async move { Client::get(&url).await.unwrap() },
-        ));
+        let u = url.clone();
+        tasks.push(tokio::spawn(async move { Client::get(&u).await.unwrap() }));
+    }
+    // Also request the same endpoint including a trailing slash.
+    for _ in 0..5 {
+        let u = url_with_slash.clone();
+        tasks.push(tokio::spawn(async move { Client::get(&u).await.unwrap() }));
     }
 
     for t in tasks {


### PR DESCRIPTION
## Summary
- handle root path correctly when formatting `Uri`
- adjust redirection test to match new URI string
- allow trailing `/` in client-server integration test
- use complete version of `take_while` to parse `/`

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685beb5bfd20832fa430d507b9638f94